### PR TITLE
Fixed #2563: FasterCasting char property incorrectly affecting spell …

### DIFF
--- a/docs/REVISIONS-56-SERIES.TXT
+++ b/docs/REVISIONS-56-SERIES.TXT
@@ -2725,3 +2725,13 @@ Added MAGIFC_NOREVEALINVISIBLE		02000	// (Old style backwards) Casts won't revea
 
 09-11-2015, Coruja
 Fixed: Mounts disappearing on world save when ridden by NPCs.
+
+13-11-2015, Coruja
+[sphere_skills.scp]: Fixed console error when an NPC try to use Tracking skill.
+[items/sphere_item_char_icons.scp]: Added TOL NPCs icons.
+[npcs/sphere_monsters.scp]:
+	-Updated NPCs Wild Tiger and TOL dinosaurs.
+	-Added new TOL NPCs Silverback Gorilla, Infernus, Greater Phoenix, Myrmidex Drone.
+
+16-11-2015, Coruja
+Fixed #2563: FasterCasting char property incorrectly affecting spell cast delay on chars with GM=1 set.

--- a/src/graysvr/CCharSpell.cpp
+++ b/src/graysvr/CCharSpell.cpp
@@ -2950,9 +2950,9 @@ int CChar::Spell_CastStart()
 		}
 	}
 
-	int iWaitTime = IsPriv(PRIV_GM) ? 1 : pSpellDef->m_CastTime.GetLinear(Skill_GetBase(static_cast<SKILL_TYPE>(iSkill)));
+	int iWaitTime = pSpellDef->m_CastTime.GetLinear(Skill_GetBase(static_cast<SKILL_TYPE>(iSkill)));
 	iWaitTime -= GetDefNum("FASTERCASTING", true, true) * 2;	//correct value is 0.25, but sphere can handle only 0.2
-	if ( iWaitTime < 1 )
+	if ( iWaitTime < 1 || IsPriv(PRIV_GM) )
 		iWaitTime = 1;
 
 	CScriptTriggerArgs Args(static_cast<int>(m_atMagery.m_Spell), iDifficulty, pItem);


### PR DESCRIPTION
…cast delay on chars with GM=1 set.